### PR TITLE
Add missing variable and bump marketing version to 1.3.1

### DIFF
--- a/Build.xcconfig
+++ b/Build.xcconfig
@@ -1,7 +1,7 @@
 // Configuration settings file format documentation can be found at:
 // https://help.apple.com/xcode/#/dev745c5c974
 
-MARKETING_VERSION = 1.2.1
+MARKETING_VERSION = 1.3.1
 CURRENT_PROJECT_VERSION = 1
 
 // Vars to be overwritten by `CodeSigning.xcconfig` if exists

--- a/LocalDevVPN/Localization/en.lproj/Localizable.strings
+++ b/LocalDevVPN/Localization/en.lproj/Localizable.strings
@@ -71,6 +71,7 @@
 "dropdown_language" = "Language";
 "settings" = "Settings";
 "done" = "Done";
+"cancel" = "Cancel";
 "warning_alert" = "Warning";
 "warning_message" = "Changing tunnel IP settings can disrupt your network connection. Proceed only if you are sure of what you are doing.";
 "understand_button" = "I Understand";

--- a/LocalDevVPN/Localization/pl.lproj/Localizable.strings
+++ b/LocalDevVPN/Localization/pl.lproj/Localizable.strings
@@ -43,7 +43,6 @@
 "assigned_ip" = "Przydzielony IP";
 
 /* MARK: Locales */
-
 "english" = "Angielski";
 "spanish" = "Hiszpański";
 "italian" = "Włoski";
@@ -72,10 +71,11 @@
 "dropdown_language" = "Język";
 "settings" = "Ustawienia";
 "done" = "Gotowe";
-
+"cancel" = "Anuluj";
 "warning_alert" = "Uwaga";
 "warning_message" = "Zmiana ustawień IP tunelu może zakłócić połączenie sieciowe. Kontynuuj tylko wtedy, gdy jesteś pewien tego, co robisz.";
 "understand_button" = "Rozumiem";
+
 "data_collection_policy_title" = "Polityka zbierania danych";
 "no_data_collection" = "Brak zbierania danych";
 "no_data_collection_description" = "LocalDevVPN nie zbiera danych użytkownika, informacji o ruchu ani aktywności w przeglądarce. Aplikacja tworzy lokalny tunel sieciowy, który działa wyłącznie na Twoim urządzeniu.";


### PR DESCRIPTION
- Add missing 'Cancel' option to EN Localizable.strings
- Update Polish localization strings with new cancel string
- Update MARKETING_VERSION to 1.3.1 (current in AppStore is 1.3.0)